### PR TITLE
Write fleet certificate into linux package if needed

### DIFF
--- a/pkg/packaging/linux_shared.go
+++ b/pkg/packaging/linux_shared.go
@@ -65,6 +65,12 @@ func buildNFPM(opt Options, pkger nfpm.Packager) error {
 		return errors.Wrap(err, "write postinstall script")
 	}
 
+	if opt.FleetCertificate != "" {
+		if err := writeCertificate(opt, orbitRoot); err != nil {
+			return errors.Wrap(err, "write fleet certificate")
+		}
+	}
+
 	// Pick up all file contents
 
 	contents := files.Contents{


### PR DESCRIPTION
Fix for https://github.com/fleetdm/fleet/issues/674. Adds the pem file into Linux packages as needed.

Closes https://github.com/fleetdm/fleet/issues/674